### PR TITLE
Add 'created_at' field and 'is_expired' function in SMSCode model

### DIFF
--- a/user_service/models.py
+++ b/user_service/models.py
@@ -8,7 +8,7 @@ from django.contrib.auth.models import AbstractUser, PermissionsMixin
 from django.db import models
 import random
 from user_service.manager import UserManager
-
+from django.utils import timezone
 
 class User(AbstractUser, PermissionsMixin):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
@@ -101,6 +101,7 @@ class SMSCode(models.Model):
     id = ShortUUIDField(primary_key=True, length=6, max_length=6, editable=False)
     user = models.OneToOneField(settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name='smscode')
     number = models.CharField(max_length=6, blank=False, null=False)
+    created_at = models.DateTimeField(auto_now_add=True)
 
     def __str__(self):
         return f'{self.user.username}-{self.number}'
@@ -110,3 +111,7 @@ class SMSCode(models.Model):
         self.number = str(verification_code)
 
         super().save(*args, **kwargs)
+    
+    def is_expired(self, expiration_minutes=10):
+        expiration_time = self.created_at + timezone.timedelta(minutes=expiration_minutes)
+        return timezone.now() >= expiration_time


### PR DESCRIPTION
This pull request adds the 'created_at' field and 'is_expired' function to the SMSCode model. The 'created_at' field stores the creation time of the verification code, and the 'is_expired' function checks if the verification code has expired based on a default expiration time of 10 minutes. These changes enhance the functionality of the SMSCode model by providing expiration functionality for verification codes.