### PR TITLE
Fix virtual environment naming in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Getting Started
 To run the API locally, follow these steps:
 
 1.  Clone the repository: `git clone https://github.com/yourusername/smart-learning-api.git`
-2.  Create a virtual environment: `python -m venv env`
-3.  Activate the virtual environment: `source env/bin/activate`
+2.  Create a virtual environment: `python -m venv venv`
+3.  Activate the virtual environment: `source venv/bin/activate`
 4.  Install dependencies: `pip install -r requirements.txt`
 5.  Change `.env.templates` to .env and setup you environment variables. 
 6.  Set up the database: `python manage.py migrate`


### PR DESCRIPTION
Modified the README file to update the instructions for creating and activating the virtual environment. Replaced 'env' with 'venv' to align with the .gitignore file that ignores the 'venv' directory.

Updated step 2 to: Create a virtual environment: `python -m venv venv`
Updated step 3 to: Activate the virtual environment: `source venv/bin/activate`