### PR TITLE
Added appropriate view for the Confirmsmsserializer 

### DIFF
--- a/user_service/tests.py
+++ b/user_service/tests.py
@@ -1,7 +1,7 @@
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
-from user_service.models import User
+from user_service.models import User, SMSCode
 
 class UserServiceTestCase(APITestCase):
 
@@ -65,3 +65,79 @@ class UserServiceTestCase(APITestCase):
          }
          response = self.client.post(url, data)
          self.assertEqual(response.status_code, status.HTTP_200_OK)
+        
+        
+
+class SMSCodeModelTestCase(APITestCase):
+
+    def setUp(self):
+
+        self.user = User.objects.create_user(
+
+            username='testuser',
+
+            email='testuser@test.com',
+
+            password='testpass'
+
+        )
+
+        self.sms_code = SMSCode.objects.create(
+
+            user=self.user,
+
+            number='123456'
+
+        )
+
+    def test_sms_code_str(self):
+
+        expected = f'{self.user.username}-123456'
+
+        self.assertEqual(str(self.sms_code), expected)
+
+    def test_sms_code_number_generated(self):
+
+        self.assertEqual(len(self.sms_code.number), 6)
+
+    def test_sms_code_is_expired(self):
+
+        # Verify that SMS code is not expired yet
+
+        self.assertFalse(self.sms_code.is_expired())
+
+        # Set created_at to more than 10 minutes ago
+
+        self.sms_code.created_at = timezone.now() - timezone.timedelta(minutes=11)
+
+        self.sms_code.save()
+
+        # Verify that SMS code is expired
+
+        self.assertTrue(self.sms_code.is_expired())
+
+    def test_create_sms_code(self):
+
+        url = reverse('sms_code')
+
+        self.client = APIClient()
+
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.post(url, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        self.assertEqual(SMSCode.objects.count(), 2)
+
+    def test_create_sms_code_without_auth(self):
+
+        url = reverse('sms_code')
+
+        self.client = APIClient()
+
+        response = self.client.post(url, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+        self.assertEqual(SMSCode.objects.count(), 1)


### PR DESCRIPTION
This view provides a GET endpoint to retrieve all SMSCode instances in the database and a POST endpoint to confirm the SMS code sent to a user.

For the POST endpoint, the view first validates the input using the ConfirmSmsSerializer. If the input is valid, it checks if a SMSCode instance with the given number exists in the database. If not, it returns a 404 NOT FOUND response. If the instance is found, it checks if the code has expired. If it has, it returns a 400 BAD REQUEST response. If the code is still valid, it returns a 200 OK response to confirm the code.