### PR TITLE
Added twilo API credentials 

### DIFF
--- a/smart_learning/settings.py
+++ b/smart_learning/settings.py
@@ -192,6 +192,16 @@ SWAGGER_SETTINGS = {
 
 STRIPE_SECRET = os.getenv('STRIPE_SECRET')
 
+# Twilio Account SID and Auth Token
+
+TWILIO_ACCOUNT_SID = os.getenv('TWILIO_ACCOUNT_SID')
+
+TWILIO_AUTH_TOKEN = os.getenv('TWILIO_AUTH_TOKEN')
+
+# Twilio phone number used for sending SMS messages
+
+TWILIO_PHONE_NUMBER = os.getenv('TWILIO_PHONE_NUMBER')
+
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/4.1/howto/static-files/
 

--- a/user_service/tests.py
+++ b/user_service/tests.py
@@ -1,7 +1,7 @@
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
-from user_service.models import User
+from user_service.models import User, SMSCode
 
 class UserServiceTestCase(APITestCase):
 
@@ -65,3 +65,79 @@ class UserServiceTestCase(APITestCase):
          }
          response = self.client.post(url, data)
          self.assertEqual(response.status_code, status.HTTP_200_OK)
+        
+        
+
+class SMSCodeModelTestCase(APITestCase):
+
+    def setUp(self):
+
+        self.user = User.objects.create_user(
+
+            username='testuser',
+
+            email='testuser@test.com',
+
+            password='testpass'
+
+        )
+
+        self.sms_code = SMSCode.objects.create(
+
+            user=self.user,
+
+            number='123456'
+
+        )
+
+    def test_sms_code_str(self):
+
+        expected = f'{self.user.username}-123456'
+
+        self.assertEqual(str(self.sms_code), expected)
+
+    def test_sms_code_number_generated(self):
+
+        self.assertEqual(len(self.sms_code.number), 6)
+
+    def test_sms_code_is_expired(self):
+
+        # Verify that SMS code is not expired yet
+
+        self.assertFalse(self.sms_code.is_expired())
+
+        # Set created_at to more than 10 minutes ago
+
+        self.sms_code.created_at = timezone.now() - timezone.timedelta(minutes=11)
+
+        self.sms_code.save()
+
+        # Verify that SMS code is expired
+
+        self.assertTrue(self.sms_code.is_expired())
+
+    def test_create_sms_code(self):
+
+        url = reverse('sms_code')
+
+        self.client = APIClient()
+
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.post(url, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        self.assertEqual(SMSCode.objects.count(), 2)
+
+    def test_create_sms_code_without_auth(self):
+
+        url = reverse('sms_code')
+
+        self.client = APIClient()
+
+        response = self.client.post(url, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+        self.assertEqual(SMSCode.objects.count(), 1)


### PR DESCRIPTION
Here's what each configuration setting does:

TWILIO_ACCOUNT_SID: This is your Twilio account's unique identifier, which you can find in your Twilio Console dashboard.
TWILIO_AUTH_TOKEN: This is your Twilio account's authorization token, which you can also find in your Twilio Console dashboard.
TWILIO_PHONE_NUMBER: This is the phone number associated with your Twilio account that you'll use to send SMS messages.
Make sure to replace your_account_sid and your_auth_token with your actual Twilio account SID and auth token, respectively. Also, make sure to install the Twilio Python library (twilio) using pip so that your Django project can use it.