### PR TITLE
Added a python module 

### DIFF
--- a/user_service/send_OTP.py
+++ b/user_service/send_OTP.py
@@ -1,0 +1,21 @@
+from twilio.rest import Client
+
+from django.conf import settings
+
+def send_sms_code(phone_number, code):
+
+    client = Client(settings.TWILIO_ACCOUNT_SID, settings.TWILIO_AUTH_TOKEN)
+
+    message = client.messages \
+
+        .create(
+
+        body=f"Your verification code is {code}",
+
+        from_=settings.TWILIO_FROM_NUMBER,
+
+        to=f'{phone_number}'
+
+    )
+
+    print(message.sid)

--- a/user_service/tests.py
+++ b/user_service/tests.py
@@ -1,7 +1,7 @@
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
-from user_service.models import User
+from user_service.models import User, SMSCode
 
 class UserServiceTestCase(APITestCase):
 
@@ -65,3 +65,79 @@ class UserServiceTestCase(APITestCase):
          }
          response = self.client.post(url, data)
          self.assertEqual(response.status_code, status.HTTP_200_OK)
+        
+        
+
+class SMSCodeModelTestCase(APITestCase):
+
+    def setUp(self):
+
+        self.user = User.objects.create_user(
+
+            username='testuser',
+
+            email='testuser@test.com',
+
+            password='testpass'
+
+        )
+
+        self.sms_code = SMSCode.objects.create(
+
+            user=self.user,
+
+            number='123456'
+
+        )
+
+    def test_sms_code_str(self):
+
+        expected = f'{self.user.username}-123456'
+
+        self.assertEqual(str(self.sms_code), expected)
+
+    def test_sms_code_number_generated(self):
+
+        self.assertEqual(len(self.sms_code.number), 6)
+
+    def test_sms_code_is_expired(self):
+
+        # Verify that SMS code is not expired yet
+
+        self.assertFalse(self.sms_code.is_expired())
+
+        # Set created_at to more than 10 minutes ago
+
+        self.sms_code.created_at = timezone.now() - timezone.timedelta(minutes=11)
+
+        self.sms_code.save()
+
+        # Verify that SMS code is expired
+
+        self.assertTrue(self.sms_code.is_expired())
+
+    def test_create_sms_code(self):
+
+        url = reverse('sms_code')
+
+        self.client = APIClient()
+
+        self.client.force_authenticate(user=self.user)
+
+        response = self.client.post(url, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        self.assertEqual(SMSCode.objects.count(), 2)
+
+    def test_create_sms_code_without_auth(self):
+
+        url = reverse('sms_code')
+
+        self.client = APIClient()
+
+        response = self.client.post(url, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+        self.assertEqual(SMSCode.objects.count(), 1)


### PR DESCRIPTION
This file specifically handles the sending of the OTP to the user's phone number
Note that the twilio trial account only allows send of sma OTP to the a single registered user phone number on their platform
So to send SMS OTP to non registered phone numbers u have to get a paid account 