### PR TITLE
DELETE BasicAuthentication

### DIFF
--- a/smart_learning/settings.py
+++ b/smart_learning/settings.py
@@ -84,7 +84,6 @@ MIDDLEWARE = [
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (       
         'rest_framework_simplejwt.authentication.JWTAuthentication',
-        'rest_framework.authentication.BasicAuthentication',
     ),
     'DEFAULT_PERMISSION_CLASSES': (
         'rest_framework.permissions.IsAuthenticated',


### PR DESCRIPTION
I have deleted 'rest_framework.authentication.BasicAuthentication' from settings.DEFAULT_AUTHENTICATION_CLASSES because it is not needed anymore.